### PR TITLE
Run CI when editing pnpm-lock.yaml

### DIFF
--- a/.github/workflows/common-ci.yml
+++ b/.github/workflows/common-ci.yml
@@ -6,6 +6,7 @@ on:
       - 'modules/common/**'
       - '.github/workflows/common-ci.yml'
       - 'pnpm-lock.yaml'
+  merge_group:
 
 defaults:
   run:

--- a/.github/workflows/common-ci.yml
+++ b/.github/workflows/common-ci.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'modules/common/**'
       - '.github/workflows/common-ci.yml'
+      - 'pnpm-lock.yaml'
 
 defaults:
   run:

--- a/.github/workflows/pos-ci.yml
+++ b/.github/workflows/pos-ci.yml
@@ -7,6 +7,7 @@ on:
       - 'modules/common/**'
       - '.github/workflows/common-ci.yml'
       - 'pnpm-lock.yaml'
+  merge_group:
 
 defaults:
   run:

--- a/.github/workflows/pos-ci.yml
+++ b/.github/workflows/pos-ci.yml
@@ -6,6 +6,7 @@ on:
       - 'services/pos/**'
       - 'modules/common/**'
       - '.github/workflows/common-ci.yml'
+      - 'pnpm-lock.yaml'
 
 defaults:
   run:

--- a/.github/workflows/pos-deploy-merge.yml
+++ b/.github/workflows/pos-deploy-merge.yml
@@ -10,6 +10,7 @@ on:
       - "services/pos/**"
       - "modules/common/**"
       - ".github/workflows/pos-deploy-merge.yml"
+      - "pnpm-lock.yaml"
 
 defaults:
   run:
@@ -28,7 +29,7 @@ jobs:
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CAFEORE_2024 }}
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_CAFEORE_2024 }}"
           channelId: live
           projectId: cafeore-2024
           entryPoint: services/pos

--- a/.github/workflows/pos-deploy-pull-request.yml
+++ b/.github/workflows/pos-deploy-pull-request.yml
@@ -7,6 +7,7 @@ on:
       - "services/pos/**"
       - "modules/common/**"
       - ".github/workflows/pos-deploy-pull-request.yml"
+      - "pnpm-lock.yaml"
 
 defaults:
   run:
@@ -31,6 +32,6 @@ jobs:
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CAFEORE_2024 }}
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_CAFEORE_2024 }}"
           projectId: cafeore-2024
           entryPoint: services/pos


### PR DESCRIPTION
dependant bot 用に pnpm-lock.yaml が編集された時に typecheck が走るように修正